### PR TITLE
Move frame buffer output to a separate thread

### DIFF
--- a/src/engine/game/game.c
+++ b/src/engine/game/game.c
@@ -78,6 +78,9 @@ int loop() {
         // df::EventBeforeDraw p_bd_event = df::EventBeforeDraw();
         // onEvent(&p_bd_event);
 
+        // Check that it's okay to write to the buffer
+        sem_wait(&screen_manager.writes_allowed);
+
         // Ui layer is always on top and opaque. 
         // Ui will render INT_MAX to the depth buffer.
         int elementsRendered = renderUi();
@@ -90,21 +93,24 @@ int loop() {
         int objectsRendered = renderObjects();
         writeLog(LOG_GAME_V, "game::loop(): Rendered %d objects", objectsRendered);
 
-        renderScreens();
+        // Let the renderer know that we're done preparing the frame
+        sem_post(&screen_manager.reads_allowed);
 
         // swapScreen();
 
+        // TODO: we can't safely write the status line anymore because
+        // the game loop doesn't own output
         if (frame_count % 30 == 0) {
             loop_time_saved = loop_time;
         }
-        printf("\e[1G\e[%dC", 0);
-        printf(" Loop: %5d ", loop_time_saved);
-        printf("Frame: %3d ", frame_count);
+        // printf("\e[1G\e[%dC", 0);
+        // printf(" Loop: %5d ", loop_time_saved);
+        // printf("Frame: %3d ", frame_count);
         // printf("Inits: %3d ", screen.times_init);
         // printf("Lines: %3d ", screen.ts.lines);
         // printf("Cols: %3d ", screen.ts.cols);
-        printf("Obj rendered: %3d ", objectsRendered);
-        fflush(stdout);
+        // printf("Obj rendered: %3d ", objectsRendered);
+        // fflush(stdout);
 
         // Swap graphics buffers
         // df::GraphicsManager &graphics_manager =

--- a/src/engine/log/log.c
+++ b/src/engine/log/log.c
@@ -3,15 +3,19 @@
 // Library
 #include <stdarg.h>
 #include <stdio.h>
+#include <pthread.h>
 
 // Engine
 #include "utility/clock.h"
 #include "game/game.h"
 
+static pthread_mutex_t log_mutex;
+
 void initLog() {
     flushLog = 1;
     logLevel = LOG_LEVEL_DEFAULT;
     relixLogFile = fopen(LOG_FILE, "w");
+    pthread_mutex_init(&log_mutex, NULL);
 
     writeLog(LOG_INIT, "log::initLog(): Initialized logging");
 }
@@ -19,6 +23,7 @@ void initLog() {
 void closeLog() {
     writeLog(LOG_INIT, "log::closeLog(): Closing logging");
     fclose(relixLogFile);
+    pthread_mutex_destroy(&log_mutex);
 }
 
 void setFlush(unsigned int on) {
@@ -66,6 +71,9 @@ int nwriteLog(int level, const char *format, ...) {
                 //if (this->p_f && this->isStarted()) {
     // Print timestring and frame number to log file
     // df::GameManager &game_manager = df::GameManager::getInstance();
+
+    pthread_mutex_lock(&log_mutex);
+
     fprintf(relixLogFile, "%8s  %6d : ", timeString(), frame_count);
     // Format arguments
     va_list args;
@@ -79,6 +87,9 @@ int nwriteLog(int level, const char *format, ...) {
     if (flushLog) {
         fflush(relixLogFile);
     }
+
+    pthread_mutex_unlock(&log_mutex);
+
     return chars_printed;
     // }
     // }

--- a/src/engine/term/screen.c
+++ b/src/engine/term/screen.c
@@ -24,6 +24,7 @@ void initScreen(Screen *screen) {
     if (screen->times_init > 0) {
         free(screen->light_buffer);
         free(screen->pixel_buffer);
+        free(screen->current_pixel_buffer);
         free(screen->prev_pixel_buffer);
     } else {
         screen->id = screen_id_iterator++;
@@ -47,9 +48,11 @@ void initScreen(Screen *screen) {
 
     setCamera(screen, (Point){0, 0, 0});
     
+    size_t screen_size = sizeof(Pixel) * screen->ts.cols * screen->ts.lines;
     screen->light_buffer = malloc(sizeof(Color) * screen->ts.cols * screen->ts.lines);
-    screen->pixel_buffer = malloc(sizeof(Pixel) * screen->ts.cols * screen->ts.lines);
-    screen->prev_pixel_buffer = malloc(sizeof(Pixel) * screen->ts.cols * screen->ts.lines);
+    screen->pixel_buffer = malloc(screen_size);
+    screen->current_pixel_buffer = malloc(screen_size);
+    screen->prev_pixel_buffer = malloc(screen_size);
 
     clearScreen(screen);
 
@@ -57,6 +60,8 @@ void initScreen(Screen *screen) {
         screen->prev_pixel_buffer[i].bg = -1;
         screen->prev_pixel_buffer[i].fg = -1;
         screen->prev_pixel_buffer[i].chr = -1;
+
+        screen->current_pixel_buffer[i] = PIXEL_NULL;
     }
 }
 
@@ -73,6 +78,7 @@ void clearScreen(Screen *screen) {
 int closeScreen(Screen *screen) {
     free(screen->light_buffer);
     free(screen->pixel_buffer);
+    free(screen->current_pixel_buffer);
     free(screen->prev_pixel_buffer);
 
     return 0;

--- a/src/engine/term/screen.h
+++ b/src/engine/term/screen.h
@@ -1,6 +1,8 @@
 #ifndef __SCREEN_H__
 #define __SCREEN_H__
 
+#include <semaphore.h>
+
 // Engine
 #include "color.h"
 #include "term.h"
@@ -19,7 +21,12 @@ typedef struct Screen {
     Rect camera_bounds;
 
     Color *light_buffer;
+
+    // Current frame that the engine draws to
     Pixel *pixel_buffer;
+
+    // Current frame that the screen manager is piping out
+    Pixel *current_pixel_buffer;
 
     // Refers to previous frame
     Pixel *prev_pixel_buffer;
@@ -31,6 +38,9 @@ typedef struct ScreenManager {
     Screen main_screen;
 
     Tree screen_tree;
+
+    sem_t writes_allowed;
+    sem_t reads_allowed;
 } ScreenManager;
 
 ScreenManager screen_manager;

--- a/src/engine/term/screenManager.c
+++ b/src/engine/term/screenManager.c
@@ -6,10 +6,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <wchar.h>
+#include <pthread.h>
 
 #include "utility/utility.h"
+#include "log/log.h"
 
 static int resize_flag;
+static int abort_output_thread_flag;
+static pthread_t output_thread;
 
 // SIGWINCH is called when the window is resized.
 // void handle_winch(int sig) {
@@ -17,8 +21,21 @@ void handle_winch() {
     resize_flag = 1;
 }
 
+void *outputThreadWork() {
+    writeLog(LOG_SCREEN, "screenManager::outputThreadWork output thread started");
+    while (!abort_output_thread_flag) {
+        renderScreens();
+    }
+    writeLog(LOG_SCREEN, "screenManager::outputThreadWork output thread exiting");
+    return 0;
+}
+
 void initScreenManager() {
+    // writes_allowed starts at 1 to allow the first frame to render
+    sem_init(&screen_manager.writes_allowed, 0, 1);
+    sem_init(&screen_manager.reads_allowed, 0, 0);
     resize_flag = 0;
+    abort_output_thread_flag = 0;
 
 #if defined __linux__
     signal(SIGWINCH, handle_winch);
@@ -37,9 +54,18 @@ void initScreenManager() {
     printf("\e[1m");
     // Clear terminal
     printf("\033[2J");
+
+    pthread_create(&output_thread, NULL, outputThreadWork, NULL);
 }
 
 void closeScreenManager() {
+    // Safely terminate the output thread
+    // There's no way that the engine can write to the buffer anymore, so wake
+    // up the output thread to flush the last frame and check the exit flag.
+    abort_output_thread_flag = 1;
+    sem_post(&screen_manager.reads_allowed);
+    pthread_join(output_thread, NULL);
+    
     Iterator *it;
     it = initIterator(&screen_manager.screen_tree);
     while (!done(it)) {
@@ -49,6 +75,9 @@ void closeScreenManager() {
     closeIterator(it);
 
     closeScreen(&screen_manager.main_screen);
+
+    sem_destroy(&screen_manager.reads_allowed);
+    sem_destroy(&screen_manager.writes_allowed);
 
     // Reset colors
     printf("\e[39m\e[49m");
@@ -64,6 +93,12 @@ void closeScreenManager() {
 }
 
 int renderScreens() {
+    Screen *screen = &screen_manager.main_screen;
+
+    // Wait for the engine to finish preparing this frame
+    sem_wait(&screen_manager.reads_allowed);
+
+    // Resizing can only happen when the engine isn't touching the buffer
     if (resize_flag) {
         resize_flag = 0;
         Iterator *it;
@@ -79,6 +114,17 @@ int renderScreens() {
         // Clear terminal
         printf("\033[2J");
     }
+
+    // Copy the prepared frame into our thread's internal buffer
+    // This will result in a blank frame if the window was resized
+    memcpy(screen->current_pixel_buffer, screen->pixel_buffer, sizeof(Pixel) * screen->ts.cols * screen->ts.lines);
+
+    // Clear the shared buffers
+    clearScreen(screen);
+
+    // Let the engine know that it's safe to continue rendering
+    sem_post(&screen_manager.writes_allowed);
+
     int i, j;
     unsigned int index;
     // Refers to preceding pixel in the row
@@ -86,8 +132,6 @@ int renderScreens() {
 
     unsigned char fg, bg;
     char chr;
-
-    Screen *screen = &screen_manager.main_screen;
 
     // Line-buffer
     // TODO: Clear still-reachable memory block (not a leak)
@@ -106,9 +150,9 @@ int renderScreens() {
         for (i = 0; i < screen->ts.cols; i++) {
             index = i + j * screen->ts.cols;
 
-            fg = screen->pixel_buffer[index].fg;
-            bg = screen->pixel_buffer[index].bg;
-            chr = screen->pixel_buffer[index].chr;
+            fg = screen->current_pixel_buffer[index].fg;
+            bg = screen->current_pixel_buffer[index].bg;
+            chr = screen->current_pixel_buffer[index].chr;
             
             // Check if pixel was unchanged from last frame
             if (fg == screen->prev_pixel_buffer[index].fg &&
@@ -140,9 +184,7 @@ int renderScreens() {
 
     free(buffer);
 
-    memcpy(screen->prev_pixel_buffer, screen->pixel_buffer, sizeof(Pixel) * screen->ts.cols * screen->ts.lines);
-
-    clearScreen(screen);
+    memcpy(screen->prev_pixel_buffer, screen->current_pixel_buffer, sizeof(Pixel) * screen->ts.cols * screen->ts.lines);
 
     fwrite("\e[0m", sizeof(char), 5, stdout);
     fflush(stdout);


### PR DESCRIPTION
The engine can run simulation while the output thread writes to stdout. Blocks will only happen if the output thread is attempting to read from the shared framebuffer while the engine prepares the frame, but this is unlikely because the output thread maintains its own internal buffer.